### PR TITLE
KSP2 0.1.5.0

### DIFF
--- a/CommunityResources.sln
+++ b/CommunityResources.sln
@@ -1,22 +1,28 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{70C57300-2431-4824-B9F3-4522377BD657}") = "CommunityResources", "src\CommunityResources\CommunityResources.csproj", "{2A62527B-B543-4E5A-A197-D28C37F282D8}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33530.505
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityResources", "src\CommunityResources\CommunityResources.csproj", "{2A62527B-B543-4E5A-A197-D28C37F282D8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Deploy|Any CPU = Deploy|Any CPU
 		DeployAndRun|Any CPU = DeployAndRun|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Debug|Any CPU.ActiveCfg = DeployAndRun|Any CPU
+		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Debug|Any CPU.Build.0 = DeployAndRun|Any CPU
 		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Deploy|Any CPU.ActiveCfg = Deploy|Any CPU
 		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Deploy|Any CPU.Build.0 = Deploy|Any CPU
 		{2A62527B-B543-4E5A-A197-D28C37F282D8}.DeployAndRun|Any CPU.ActiveCfg = DeployAndRun|Any CPU
 		{2A62527B-B543-4E5A-A197-D28C37F282D8}.DeployAndRun|Any CPU.Build.0 = DeployAndRun|Any CPU
+		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A62527B-B543-4E5A-A197-D28C37F282D8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/plugin_template/swinfo.json
+++ b/plugin_template/swinfo.json
@@ -1,23 +1,23 @@
 {
-  "spec": "1.3",
-  "mod_id": "CommunityResources",
-  "author": "KSP2 Community",
-  "name": "Community Resources",
-  "description": "A mod to add generic resources for mods to use",
-  "source": "https://github.com/KSP2Community/CommunityResources",
-  "version": "0.1.0",
-  "version_check": "https://raw.githubusercontent.com/KSP2Community/CommunityResources/main/swinfo.json",
-  "ksp2_version": {
-    "min": "0.1.3",
-    "max": "*"
-  },
-  "dependencies": [
-    {
-      "id": "com.github.x606.spacewarp",
-      "version": {
-        "min": "1.4.0",
+    "spec": "1.3",
+    "mod_id": "CommunityResources",
+    "author": "KSP2 Community",
+    "name": "Community Resources",
+    "description": "A mod to add generic resources for mods to use",
+    "source": "https://github.com/KSP2Community/CommunityResources",
+    "version": "0.1.0",
+    "version_check": "https://raw.githubusercontent.com/KSP2Community/CommunityResources/main/swinfo.json",
+    "ksp2_version": {
+        "min": "0.1.3",
         "max": "*"
-      }
+    },
+    "dependencies": [
+    {
+        "id": "com.github.x606.spacewarp",
+        "version": {
+            "min": "1.4.0",
+            "max": "*"
+        }
     },
     {
         "id": "PatchManager",
@@ -26,5 +26,5 @@
             "max": "*"
         }
     }
-  ]
+    ]
 }

--- a/plugin_template/swinfo.json
+++ b/plugin_template/swinfo.json
@@ -3,12 +3,12 @@
     "mod_id": "CommunityResources",
     "author": "KSP2 Community",
     "name": "Community Resources",
-    "description": "A mod to add generic resources for mods to use",
+    "description": "Adds generic resources for mods to use",
     "source": "https://github.com/KSP2Community/CommunityResources",
     "version": "0.1.0",
-    "version_check": "https://raw.githubusercontent.com/KSP2Community/CommunityResources/main/swinfo.json",
+    "version_check": "https://raw.githubusercontent.com/KSP2Community/CommunityResources/main/plugin_template/swinfo.json",
     "ksp2_version": {
-        "min": "0.1.3",
+        "min": "0.1.4",
         "max": "*"
     },
     "dependencies": [
@@ -22,7 +22,7 @@
     {
         "id": "PatchManager",
         "version": {
-            "min": "0.1.0",
+            "min": "0.2.0",
             "max": "*"
         }
     }

--- a/src/CommunityResources/CommunityResources.csproj
+++ b/src/CommunityResources/CommunityResources.csproj
@@ -3,6 +3,7 @@
     <!-- Project references -->
     <PropertyGroup>
       <RootNamespace>CommunityResourceUnits</RootNamespace>
+      <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup Label="NuGet package references">
         <!-- Add references to any NuGet packages you want to use in your mod here -->
@@ -11,9 +12,10 @@
         <PackageReference Include="BepInEx.Core" Version="5.*" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
         <PackageReference Include="HarmonyX" Version="2.10.1" />
-        <PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.1.4" PrivateAssets="all" />
+        <PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.1.5" PrivateAssets="all" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="PatchManager" Version="0.1.1" />
-        <PackageReference Include="SpaceWarp" Version="1.4.0" />
-        <PackageReference Include="UnityEngine.Modules" Version="2020.3.33.1" />
+        <PackageReference Include="SpaceWarp" Version="1.5.2" />
+        <PackageReference Include="UnityEngine.Modules" Version="2022.3.5" />
     </ItemGroup>
 </Project>

--- a/src/CommunityResources/Patches.cs
+++ b/src/CommunityResources/Patches.cs
@@ -4,7 +4,7 @@ using KSP.Modules;
 using KSP.Sim.Definitions;
 using KSP.Sim.ResourceSystem;
 using KSP.UI;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+// using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CommunityResourceUnits;
 


### PR DESCRIPTION
This provides the updates needed to support ksp2 0.1.5.0 and spacewarp 1.5.2
It changes the .net version to .net standard 2.1, the ksp2 version to 0.1.5.0, the unity version to 2022.3.5, and the newtonsoft.json version to 13.0.3