### PR TITLE
Change life-support flow mode

### DIFF
--- a/plugin_template/patches/gasses.patch
+++ b/plugin_template/patches/gasses.patch
@@ -34,7 +34,7 @@
 	massPerUnit: 1;
 	volumePerUnit: 4;
 	specificHeatCapacityPerUnit: 920;
-	flowMode: $FM_STAGE_PRIORITY_FLOW;
+	flowMode: $FM_STACK_PRIORITY_SEARCH;
 	transferMode: $TM_PUMP;
 	costPerUnit: 0.8;
 	NonStageable: true;
@@ -51,7 +51,7 @@
 	massPerUnit: 1;
 	volumePerUnit: 4;
 	specificHeatCapacityPerUnit: 850;
-	flowMode: $FM_STAGE_PRIORITY_FLOW;
+	flowMode: $FM_STACK_PRIORITY_SEARCH;
 	transferMode: $TM_PUMP;
 	costPerUnit: 0.8;
 	NonStageable: false;

--- a/plugin_template/patches/liquids.patch
+++ b/plugin_template/patches/liquids.patch
@@ -34,7 +34,7 @@
 	massPerUnit: 0.001;
 	volumePerUnit: 1;
 	specificHeatCapacityPerUnit: 4.184;
-	flowMode: $FM_STAGE_PRIORITY_FLOW;
+	flowMode: $FM_STACK_PRIORITY_SEARCH;
 	transferMode: $TM_PUMP;
 	costPerUnit: 0.8;
 	NonStageable: true;
@@ -51,7 +51,7 @@
 	massPerUnit: 0.001;
 	volumePerUnit: 1;
 	specificHeatCapacityPerUnit: 4.184;
-	flowMode: $FM_STAGE_PRIORITY_FLOW;
+	flowMode: $FM_STACK_PRIORITY_SEARCH;
 	transferMode: $TM_PUMP;
 	costPerUnit: 0.8;
 	NonStageable: false;

--- a/plugin_template/patches/solids.patch
+++ b/plugin_template/patches/solids.patch
@@ -34,7 +34,7 @@
 	massPerUnit: 1;
 	volumePerUnit: 5;
 	specificHeatCapacityPerUnit: 1000;
-	flowMode: $FM_STAGE_PRIORITY_FLOW;
+	flowMode: $FM_STACK_PRIORITY_SEARCH;
 	transferMode: $TM_PUMP;
 	costPerUnit: 0.8;
 	NonStageable: true;
@@ -51,7 +51,7 @@
 	massPerUnit: 1;
 	volumePerUnit: 3;
 	specificHeatCapacityPerUnit: 800;
-	flowMode: $FM_STAGE_PRIORITY_FLOW;
+	flowMode: $FM_STACK_PRIORITY_SEARCH;
 	transferMode: $TM_PUMP;
 	costPerUnit: 0.8;
 	NonStageable: false;

--- a/plugin_template/swinfo.json
+++ b/plugin_template/swinfo.json
@@ -5,7 +5,7 @@
     "name": "Community Resources",
     "description": "Adds generic resources for mods to use",
     "source": "https://github.com/KSP2Community/CommunityResources",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "version_check": "https://raw.githubusercontent.com/KSP2Community/CommunityResources/main/plugin_template/swinfo.json",
     "ksp2_version": {
         "min": "0.1.5",


### PR DESCRIPTION
Change the flow mode of life-support resources to `FM_STACK_PRIORITY_SEARCH` in order to ignore parts that disable fuel flow like decouplers.